### PR TITLE
Dont call zstrmDestruct unless the function pointer is valid

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1325,7 +1325,7 @@ CODESTARTobjDestruct(strm)
 	 * IMPORTANT: we MUST free this only AFTER the ansyncWriter has been stopped, else
 	 * we get random errors...
 	 */
-	if(pThis->compressionDriver == STRM_COMPRESS_ZSTD) {
+	if(pThis->compressionDriver == STRM_COMPRESS_ZSTD && zstdw.Destruct) {
 		zstdw.Destruct(pThis);
 	}
 	if(pThis->prevLineSegment)


### PR DESCRIPTION
It is possible to set the compression driver in `omfile` but disable it (by  not using a zipLevel). This seems to cause this function pointer to be NULL at this point. As such, without this patch you can get a SEGV on a HUP.